### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/detiber/k8s-jumperless/security/code-scanning/6](https://github.com/detiber/k8s-jumperless/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow, specifying the minimal required permissions. Since the workflow only checks out code and runs a linter, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the root level of the workflow file (above the `jobs:` key), so it applies to all jobs in the workflow. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
