### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/detiber/k8s-jumperless/security/code-scanning/5](https://github.com/detiber/k8s-jumperless/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
