### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: E2E Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/detiber/k8s-jumperless/security/code-scanning/4](https://github.com/detiber/k8s-jumperless/security/code-scanning/4)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and runs tests, it only needs `contents: read` permission. The best way to do this is to add a `permissions: contents: read` block at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the restriction to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
